### PR TITLE
add(decisions): apply decisions by accountId, userId and sessionId

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,21 @@ client.events.create({
 
 ### [Apply Decisions](https://siftscience.com/developers/docs/curl/decisions-api/apply-decisions)
 
+#### User decision
 ```javascript
 client.decisions.applyByAccountIdAndUserId('accountId', 'userId', {
+  decision_id : 'user_looks_ok_payment_abuse'
+});
+```
+#### Order decision
+```javascript
+client.decisions.applyByAccountIdAndOrderId('accountId', 'userId', 'orderId', {
+  decision_id : 'user_looks_ok_payment_abuse'
+});
+```
+#### Session decision
+```javascript
+client.decisions.applyByAccountIdAndSessionId('accountId', 'userId', 'sessionId', {
   decision_id : 'user_looks_ok_payment_abuse'
 });
 ```

--- a/lib/client/decisions.js
+++ b/lib/client/decisions.js
@@ -51,6 +51,30 @@ function getDecisionsApi(siftScienceClient) {
         });
     },
     /**
+     * @param {String} accountId
+     * @param {String} sessionId
+     * @param {String} userId
+     * @param {Object} [data]
+     * @param {Object} [params]
+     * https://siftscience.com/developers/docs/curl/decisions-api/apply-decisions
+     */
+    applyByAccountIdAndSessionId(accountId, userId, sessionId, data = {}, params = {}) {
+      if (!accountId) return Promise.reject(new Error('accountId is required'));
+      if (!sessionId) return Promise.reject(new Error('sessionId is required'));
+      if (!userId) return Promise.reject(new Error('userId is required'));
+
+      return Promise.resolve(v3HttpClient.post(`/accounts/${accountId}/users/${userId}/sessions/${sessionId}/decisions`, data, params, {
+          auth: {
+            username: key
+          }
+        }))
+        .then(response => response.data)
+        .catch(error => {
+          logger.logRequestError(error);
+          throw error;
+        });
+    },
+    /**
      * @param {Object} [data]
      * @param {Object} [params]
      * https://siftscience.com/developers/docs/curl/decisions-api/decision-status

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-siftscience",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/lib/client/decision/applyByAccountIdAndOrderId-test.js
+++ b/tests/lib/client/decision/applyByAccountIdAndOrderId-test.js
@@ -150,6 +150,29 @@ describe('lib', () => {
               });
           });
         });
+
+        describe('when call return an error', () => {
+          const accountId = '123';
+          const userId = '123';
+          const orderId = '123';
+          const error = new Error('Some error');
+
+
+          before('stub v3HttpClient.post()', () => {
+            sandbox.stub(v3HttpClient, 'post')
+              .returns(Promise.reject(error));
+          });
+
+          it('should also throw error if v3HttpClient.post() throw it', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndOrderId(accountId, userId, orderId)
+              .then(should.not.exist)
+              .catch((err) => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal(error.message);
+              });
+          });
+        });
       });
     });
   });

--- a/tests/lib/client/decision/applyByAccountIdAndSessionId-test.js
+++ b/tests/lib/client/decision/applyByAccountIdAndSessionId-test.js
@@ -150,6 +150,29 @@ describe('lib', () => {
               });
           });
         });
+
+        describe('when call return an error', () => {
+          const accountId = '123';
+          const userId = '123';
+          const sessionId = '123';
+          const error = new Error('Some error');
+
+
+          before('stub v3HttpClient.post()', () => {
+            sandbox.stub(v3HttpClient, 'post')
+              .returns(Promise.reject(error));
+          });
+
+          it('should also throw error if v3HttpClient.post() throw it', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId)
+              .then(should.not.exist)
+              .catch((err) => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal(error.message);
+              });
+          });
+        });
       });
     });
   });

--- a/tests/lib/client/decision/applyByAccountIdAndSessionId-test.js
+++ b/tests/lib/client/decision/applyByAccountIdAndSessionId-test.js
@@ -1,0 +1,156 @@
+const _ = require('lodash');
+const should = require('should');
+const sinon = require('sinon');
+
+let SiftScienceClient;
+let v3HttpClient;
+let sandbox;
+
+before(() => {
+  SiftScienceClient = require('../../../../lib');
+  v3HttpClient = require('../../../../lib/client/v3HttpClient');
+
+  sandbox = sinon.sandbox.create();
+});
+
+describe('lib', () => {
+  describe('client', () => {
+    describe('decisions', () => {
+      describe('applyByAccountIdAndSessionId', () => {
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        const key = '123';
+        let siftScienceClient;
+
+        before('create siftScienceClient', () => {
+          siftScienceClient = new SiftScienceClient(key);
+        });
+
+        describe('when called without accountId', () => {
+          const accountId = null;
+          const userId = '123';
+          const sessionId = '123';
+
+          it('should reject with an error', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId)
+              .then(should.not.exist)
+              .catch(err => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal('accountId is required');
+              });
+          });
+        });
+
+        describe('when called without userId', () => {
+          const accountId = '123';
+          const sessionId = '123';
+          const userId = null;
+
+          it('should reject with an error', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId)
+              .then(should.not.exist)
+              .catch(err => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal('userId is required');
+              });
+          });
+        });
+
+        describe('when called without sessionId', () => {
+          const accountId = '123';
+          const sessionId = null;
+          const userId = '123';
+
+          it('should reject with an error', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId)
+              .then(should.not.exist)
+              .catch(err => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal('sessionId is required');
+              });
+          });
+        });
+
+        describe('when called with an accountId, userId and sessionId', () => {
+          const accountId = '123';
+          const userId = '123';
+          const sessionId = '123';
+          const data = {};
+          const response = {
+            data: {}
+          };
+
+          let postStub;
+
+          before('stub v3HttpClient.post()', () => {
+            postStub = sandbox.stub(v3HttpClient, 'post')
+              .returns(Promise.resolve(response));
+          });
+
+          it('should call v3HttpClient.post()', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId, data)
+              .then(result => {
+                should.exist(result);
+                result.should.deepEqual(response.data);
+
+                postStub.callCount.should.equal(1);
+                postStub.args[0][0].should.equal(`/accounts/${accountId}/users/${userId}/sessions/${sessionId}/decisions`);
+                postStub.args[0][1].should.deepEqual(data);
+                postStub.args[0][2].should.deepEqual({});
+                postStub.args[0][3].should.deepEqual({
+                  auth: {
+                    username: siftScienceClient._key
+                  }
+                });
+              });
+          });
+        });
+
+        describe('when called with params', () => {
+          const accountId = '123';
+          const userId = '123';
+          const sessionId = '123';
+          const data = {};
+          const params = {
+            foo: 'bar'
+          };
+          const response = {
+            data: {}
+          };
+
+          let postStub;
+
+          before('stub v3HttpClient.post()', () => {
+            postStub = sandbox.stub(v3HttpClient, 'post')
+              .returns(Promise.resolve(response));
+          });
+
+          it('should call v3HttpClient.post()', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId, data, params)
+              .then(result => {
+                should.exist(result);
+                result.should.deepEqual(response.data);
+
+                postStub.callCount.should.equal(1);
+                postStub.args[0][0].should.equal(`/accounts/${accountId}/users/${userId}/sessions/${sessionId}/decisions`);
+                postStub.args[0][1].should.deepEqual(_.extend(data, {
+                  $api_key: key
+                }));
+                postStub.args[0][2].should.deepEqual(params);
+                postStub.args[0][3].should.deepEqual({
+                  auth: {
+                    username: siftScienceClient._key
+                  }
+                });
+              });
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/lib/client/decision/applyByAccountIdAndUserId-test.js
+++ b/tests/lib/client/decision/applyByAccountIdAndUserId-test.js
@@ -129,6 +129,28 @@ describe('lib', () => {
               });
           });
         });
+
+        describe('when call return an error', () => {
+          const accountId = '123';
+          const userId = '123';
+          const error = new Error('Some error');
+
+
+          before('stub v3HttpClient.post()', () => {
+            sandbox.stub(v3HttpClient, 'post')
+              .returns(Promise.reject(error));
+          });
+
+          it('should also throw error if v3HttpClient.post() throw it', () => {
+            return siftScienceClient.decisions.applyByAccountIdAndUserId(accountId, userId)
+              .then(should.not.exist)
+              .catch((err) => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal(error.message);
+              });
+          });
+        });
       });
     });
   });

--- a/tests/lib/client/decision/getByAccountIdAndOrderId-test.js
+++ b/tests/lib/client/decision/getByAccountIdAndOrderId-test.js
@@ -123,6 +123,38 @@ describe('lib', () => {
           });
         });
       });
+
+      describe('when call return an error', () => {
+        const accountId = '123';
+        const orderId = '123';
+        const error = new Error('Some error');
+
+        const key = '123';
+        let siftScienceClient;
+
+        before('create siftScienceClient', () => {
+          siftScienceClient = new SiftScienceClient(key);
+        });
+
+        before('stub v3HttpClient.get()', () => {
+          sandbox.stub(v3HttpClient, 'get')
+            .returns(Promise.reject(error));
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should also throw error if v3HttpClient.get() throw it', () => {
+          return siftScienceClient.decisions.getByAccountIdAndOrderId(accountId, orderId)
+            .then(should.not.exist)
+            .catch((err) => {
+              should.exist(err);
+              err.should.be.instanceOf(Error);
+              err.message.should.equal(error.message);
+            });
+        });
+      });
     });
   });
 });

--- a/tests/lib/client/decision/getByAccountIdAndUserId-test.js
+++ b/tests/lib/client/decision/getByAccountIdAndUserId-test.js
@@ -123,6 +123,38 @@ describe('lib', () => {
           });
         });
       });
+
+      describe('when call return an error', () => {
+        const accountId = '123';
+        const userId = '123';
+        const error = new Error('Some error');
+
+        const key = '123';
+        let siftScienceClient;
+
+        before('create siftScienceClient', () => {
+          siftScienceClient = new SiftScienceClient(key);
+        });
+
+        before('stub v3HttpClient.get()', () => {
+          sandbox.stub(v3HttpClient, 'get')
+            .returns(Promise.reject(error));
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        it('should also throw error if v3HttpClient.get() throw it', () => {
+          return siftScienceClient.decisions.getByAccountIdAndUserId(accountId, userId)
+            .then(should.not.exist)
+            .catch((err) => {
+              should.exist(err);
+              err.should.be.instanceOf(Error);
+              err.message.should.equal(error.message);
+            });
+        });
+      });
     });
   });
 });

--- a/tests/lib/client/decision/listByAccountId-test.js
+++ b/tests/lib/client/decision/listByAccountId-test.js
@@ -105,6 +105,37 @@ describe('lib', () => {
               });
           });
         });
+
+        describe('when call return an error', () => {
+          const accountId = '123';
+          const error = new Error('Some error');
+
+          const key = '123';
+          let siftScienceClient;
+
+          before('create siftScienceClient', () => {
+            siftScienceClient = new SiftScienceClient(key);
+          });
+
+          before('stub v3HttpClient.get()', () => {
+            sandbox.stub(v3HttpClient, 'get')
+              .returns(Promise.reject(error));
+          });
+
+          afterEach(() => {
+            sandbox.restore();
+          });
+
+          it('should also throw error if v3HttpClient.get() throw it', () => {
+            return siftScienceClient.decisions.listByAccountId(accountId)
+              .then(should.not.exist)
+              .catch((err) => {
+                should.exist(err);
+                err.should.be.instanceOf(Error);
+                err.message.should.equal(error.message);
+              });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Hi there!
I'd like to use your module in project, but need one more method.
We need to apply decision by sessionId also, so I added this method with tests for it.

What should be called
```
$ curl -XPOST https://api.sift.com/v3/accounts/{accountId}/users/{userId}/sessions/{sessionId}/decisions
-H 'Content-Type: application/json' \
-u {YOUR_API_KEY}:
-d \
        '{
          "decision_id"   : "session_looks_bad_account_takeover",
          "source"        : "MANUAL_REVIEW",
          "analyst"       : "analyst@example.com",
          "description"   : "compromised account reported to customer service"
        }'
```


Usage
```
const Sift = require('node-siftscience');

const sift  = new Sift(apiKey);

siftScienceClient.decisions.applyByAccountIdAndSessionId(accountId, userId, sessionId [, data]);
```